### PR TITLE
Restructuring generator

### DIFF
--- a/Documentation/generator.md
+++ b/Documentation/generator.md
@@ -1,0 +1,11 @@
+# `hackr.generator`
+
+`hackr.generator` exposes functions that create data. It is structured as an `__init__.py` file and other modules.
+
+Any method you would like to expose in the `hackr.generator` namespace can be added to `hackr/generator/__init__.py`. Any grouping can be added by making a new `.py` file (like `hackr/generator/networking.py`) and importing it into `__init__.py` with:
+
+```python
+from internet import *
+```
+
+After importing the namespace, you can use it's methods with `hackr.generator.internet.<your method here>`.

--- a/Documentation/internet.md
+++ b/Documentation/internet.md
@@ -1,0 +1,35 @@
+# `hackr.generator.internet`
+
+`hackr.generator.internet` exposes the members of the `internet` provider from `faker`.
+
+## Methods
+Methods can be called with:
+
+```python
+>>> print(hackr.generator.internet.ipv4(3, network=True))
+['25.154.130.192/26', '136.0.0.0/6', '207.123.44.182/32']
+```
+
+All functions require a count and return that number of items in the list (even if this means that there are duplicates). All other function arguments are optional and have default values set already.
+
+All methods given below have an example included afterwards, with any arguments specified. Unless otherwise noted, `count=1`
+
+- `user_name(count, *args, **kwargs)`: Returns user names (['watersjamie'])
+- `domain_word(count, *args, **kwargs)`: Returns domain words (`['hunt-wolf']`)
+- `email(count)`: Returns  emails (`['douglas34@hotmail.com']`)
+- `url(count)`: Returns `count` urls (`['http://koch.com/']`)
+- `ipv4(count, network=False)`: Returns IP version 4 addresses. If `network` is `True`, a network prefix is added (`['48.38.136.10']`)
+- `free_email_domain(count)`: Returns domains with free email services (`['gmail.com']`) 
+- `uri_path(count, deep=None)`: Returns Uniform Resource Identifier paths with a specified depth. (`deep=5`, `['app/list/tag/list/app']`)
+- `uri(count)`: Returns whole uri (domain included). The depth of the uri is not configurable. (`['https://www.james.com/tag/wp-content/app/register/']`)
+- `mac_address(count)`: Returns Media Access Control (MAC) addresses
+- `domain_name(count, levels=1)`: Returns domain names with the specified depth (`levels=3`, `['lin.chaney.olson.org']`)
+- `free_email(count)`: Returns emails from the free email list (`['morgangregory@hotmail.com']`)
+- `uri_page(count)`: Returns a uri to a page (`count=3`, `['terms', 'privacy', 'login']`)
+- `safe_email(count)`: Returns emails that are garunteed to have no real world conflict (`['odavis@example.net']`)
+- `slug(count, *args, **kwargs)`: Returns `count` slugs (`count=3`, `['sequi-beatae', 'distinctio-corporis', 'nostrum-placeat']`)
+- `company_email(count)`: Returns emails that resemble coorporate emails (`['aellison@holmes.com']`)
+- `image_url(count, width=None, height=None)`: Returns a link to a placeholder of width and height (random by default). This link will actually go to an image (`http://www.lorempixel.com/1017/463`)
+- `tld(count)`: Returns [top level domains](https://en.wikipedia.org/wiki/Top-level_domain) (`count=5`, `['biz', 'com', 'com', 'net', 'com']`)
+- `ipv6(count, network=False)`: Returns IP version 6 addresses (`['853b:a026:23d:884f:47da:da72:5ab0:4d7c']`)
+- `uri_extension(count)`: Returns common URI extensions (`['.htm', '.asp', '.html']`)

--- a/hackr/__init__.py
+++ b/hackr/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 
 from . import generator
 from . import web

--- a/hackr/__init__.py
+++ b/hackr/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import generator
-import web
-import actions
+from . import generator
+from . import web
+from . import actions

--- a/hackr/generator.py
+++ b/hackr/generator.py
@@ -49,3 +49,120 @@ def address(count):
     for i in range(count):
         dataset.append(fake.address())
     return dataset
+
+### From faker.providers.internet
+def user_name(count, *args, **kwargs):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.user_name(*args, **kwargs))
+    return dataset
+
+def domain_word(count, *args, **kwargs):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.domain_word(*args, **kwargs))
+    return dataset
+
+def email(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.email())
+    return dataset
+
+def url(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.url())
+    return dataset
+
+def ipv4(count, network=False):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.ipv4(network=network))
+    return dataset
+
+
+def free_email_domain(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.free_email_domain())
+    return dataset
+
+def uri_path(count, deep=None):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.uri_path(deep=deep))
+    return dataset
+
+def uri(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.uri())
+    return dataset
+
+def mac_address(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.mac_address())
+    return dataset
+
+def domain_name(count, levels=1):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.domain_name(levels=levels))
+    return dataset
+
+def free_email(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.free_email())
+    return dataset
+
+def uri_page(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.uri_page())
+    return dataset
+
+def safe_email(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.safe_email())
+    return dataset
+
+def slug(count, *args, **kwargs):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.slug(*args, **kwargs))
+    return dataset
+
+def company_email(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.company_email())
+    return dataset
+
+def image_url(count, width=None, height=None):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.image_url(width=width, height=height))
+    return dataset
+
+def tld(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.tld())
+    return dataset
+
+def ipv6(count, network=False):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.ipv6(network=network))
+    return dataset
+
+def uri_extension(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.uri_extension())
+    return dataset
+### end faker.providers.internet

--- a/hackr/generator/__init__.py
+++ b/hackr/generator/__init__.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+### Any added Modules
+from .internet import *
+
+### Anything you want in hacker.generator
+import random
+import string
+from datetime import datetime
+
+from faker import Faker
+
+fake = Faker()
+
+
+def digits(end, count):
+    dataset = []
+    for i in range(count):
+        dataset.append(random.randint(0, end))
+    return dataset
+
+
+def characters(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(random.choice(string.letters))
+    return dataset
+
+
+def dates(count, start_year, end_year):
+    dataset = []
+    for i in range(count):
+        year = random.randint(start_year, end_year)
+        month = random.randint(1, 12)
+        if month != 2:
+            day = random.randint(1, 30)
+        else:
+            day = random.randint(1, 28)
+        dataset.append(str(datetime(year, month, day)))
+    return dataset  # Currently it doesn't include 31st and 29th Feb
+
+
+def names(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.name())
+    return dataset
+
+
+def address(count):
+    dataset = []
+    for i in range(count):
+        dataset.append(fake.address())
+    return dataset

--- a/hackr/generator/__init__.py
+++ b/hackr/generator/__init__.py
@@ -30,15 +30,22 @@ def characters(count):
 
 def dates(count, start_year, end_year):
     dataset = []
+    leap_year = False
     for i in range(count):
         year = random.randint(start_year, end_year)
+        if (year % 4 == 0 and year % 100 != 0) or (year % 400 == 0):
+            leap_year = True
         month = random.randint(1, 12)
-        if month != 2:
+        if month == 2 and leap_year:
+            day = random.randint(1, 29)
+        elif month == 2 and not leap_year:
+            day = random.randint(1, 28)
+        elif month == 9 or month == 4 or month == 6 or month == 11:
             day = random.randint(1, 30)
         else:
-            day = random.randint(1, 28)
+            day = random.randint(1, 31)
         dataset.append(str(datetime(year, month, day)))
-    return dataset  # Currently it doesn't include 31st and 29th Feb
+    return dataset
 
 
 def names(count):

--- a/hackr/generator/internet.py
+++ b/hackr/generator/internet.py
@@ -1,56 +1,9 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-import random
-import string
-from datetime import datetime
-
+# internet.py
+# Implementation of the faker.provider.internet methods
 from faker import Faker
 
 fake = Faker()
 
-
-def digits(end, count):
-    dataset = []
-    for i in range(count):
-        dataset.append(random.randint(0, end))
-    return dataset
-
-
-def characters(count):
-    dataset = []
-    for i in range(count):
-        dataset.append(random.choice(string.letters))
-    return dataset
-
-
-def dates(count, start_year, end_year):
-    dataset = []
-    for i in range(count):
-        year = random.randint(start_year, end_year)
-        month = random.randint(1, 12)
-        if month != 2:
-            day = random.randint(1, 30)
-        else:
-            day = random.randint(1, 28)
-        dataset.append(str(datetime(year, month, day)))
-    return dataset  # Currently it doesn't include 31st and 29th Feb
-
-
-def names(count):
-    dataset = []
-    for i in range(count):
-        dataset.append(fake.name())
-    return dataset
-
-
-def address(count):
-    dataset = []
-    for i in range(count):
-        dataset.append(fake.address())
-    return dataset
-
-### From faker.providers.internet
 def user_name(count, *args, **kwargs):
     dataset = []
     for i in range(count):
@@ -165,4 +118,3 @@ def uri_extension(count):
     for i in range(count):
         dataset.append(fake.uri_extension())
     return dataset
-### end faker.providers.internet


### PR DESCRIPTION
To avoid lumping **all** of `faker`'s functionality into one file, `generator` could be restructured. This adds complexity, but:

1. Still lets people put functionality in `faker.generator.<your function here>()` using `hackr/generator/__init__.py`
2. Lets people group new functionality into files (`faker.generator.file_name.function()`) by putting `function` within `hackr/generator/file_name` and adding `from .file_name import *` to `hackr/generator/file_name`

It also refactors `hackr/__init__.py` to make the end modification play nicely with python 2 and 3 and adds a `Documentation` directory describing how to add new items to generator and how to use `internet`