### PR TITLE
Corrected `toc`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,13 +11,3 @@ Welcome to hackr's documentation!
    :hidden:
    
    Welcome <self>
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-
-.. include:: ../README.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,9 +7,10 @@ Welcome to hackr's documentation!
 =================================
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
+   :caption: Home
+   :hidden:
+   
+   Welcome <self>
 
 
 Indices and tables


### PR DESCRIPTION
The build succeeded and generated documentation accordingly.

Build: [https://readthedocs.org/projects/hackr-pseudoaj/builds/6087638/](https://readthedocs.org/projects/hackr-pseudoaj/builds/6087638/)
Docs: http://hackr-pseudoaj.readthedocs.io/en/dev/